### PR TITLE
Switch from `notebook` to `jupyter_server`

### DIFF
--- a/jupyterlab_snippets/handlers.py
+++ b/jupyterlab_snippets/handlers.py
@@ -2,8 +2,8 @@ import json
 
 import tornado
 
-from notebook.base.handlers import APIHandler
-from notebook.utils import url_path_join
+from jupyter_server.base.handlers import APIHandler
+from jupyter_server.utils import url_path_join
 
 
 class ListSnippets(APIHandler):


### PR DESCRIPTION
Similar to https://github.com/jupyter-server/jupyter-resource-usage/pull/93, this drops `notebook` import in favor of `jupyter_server`.