### PR TITLE
Automated Changelog Entry for 0.4.1 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.4.1
+
+([Full Changelog](https://github.com/QuantStack/jupyterlab-snippets/compare/v0.4.0...928cb72793a42d5f5ae3bed4de103c4640d9fe59))
+
+### Maintenance and upkeep improvements
+
+- Update to Jupyter Packaging 10, adopt the releaser [#38](https://github.com/QuantStack/jupyterlab-snippets/pull/38) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/QuantStack/jupyterlab-snippets/graphs/contributors?from=2021-03-11&to=2021-09-30&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3AQuantStack%2Fjupyterlab-snippets+involves%3Ajtpio+updated%3A2021-03-11..2021-09-30&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.4.0
 
 ### Changes
@@ -11,5 +27,3 @@
 - Port to JupyterLab 3 #33 
 
 Many thanks @fcollonval for the contributions!
-
-<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.4.1 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | QuantStack/jupyterlab-snippets  |
| Branch  | main  |
| Version Spec | 0.4.1 |
| Since | v0.4.0 |